### PR TITLE
Adding a .desktop for future packaging

### DIFF
--- a/assets/application.desktop
+++ b/assets/application.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Baš Čelik
+Comment=A program for reading ID cards issued by the government of Serbia
+Path=/usr/bin
+Exec=bas-celik
+Terminal=false
+Icon=bas-celik
+Categories=Office


### PR DESCRIPTION
Pozdrav,

evo ga .desktop file koji trenutno hostujem na svom sajtu, i koji se trenutno koristi za ovaj [AUR paket](https://aur.archlinux.org/packages/bas-celik).

Bilo bi zgodno da se on nalazi direknto u sorce repozitorijumu, jer je github pouzdaniji host za njega.