### PR TITLE
Additional error handling 

### DIFF
--- a/card/apollo.go
+++ b/card/apollo.go
@@ -29,6 +29,9 @@ func (card Apollo) readFile(name []byte, trim bool) ([]byte, error) {
 		return nil, fmt.Errorf("reading file header: %w", err)
 	}
 
+	if len(data) < 5 {
+		return nil, fmt.Errorf("invalid file header: %w", err)
+	}
 	length := uint(binary.LittleEndian.Uint16(data[4:]))
 	offset := uint(6)
 

--- a/card/gemalto.go
+++ b/card/gemalto.go
@@ -48,8 +48,11 @@ func (card Gemalto) readFile(name []byte, trim bool) ([]byte, error) {
 		return nil, fmt.Errorf("reading file header: %w", err)
 	}
 
-	length := uint(binary.LittleEndian.Uint16(data[2:]))
 	offset := uint(len(data))
+	if offset < 3 {
+		return nil, fmt.Errorf("invalid file header: %w", err)
+	}
+	length := uint(binary.LittleEndian.Uint16(data[2:]))
 
 	for length > 0 {
 		data, err := read(card.smartCard, offset, length)

--- a/card/medical.go
+++ b/card/medical.go
@@ -204,8 +204,11 @@ func (card MedicalCard) readFile(name []byte, _ bool) ([]byte, error) {
 		return nil, fmt.Errorf("reading file header: %w", err)
 	}
 
-	length := uint(binary.LittleEndian.Uint16(data[2:]))
 	offset := uint(len(data))
+	if offset < 3 {
+		return nil, fmt.Errorf("invalid file header: %w", err)
+	}
+	length := uint(binary.LittleEndian.Uint16(data[2:]))
 
 	for length > 0 {
 		data, err := read(card.smartCard, offset, length)


### PR DESCRIPTION
Mali fix da ne radi panic ako dodje do zabune i pozove readCard za pogresnu vrstu kartice i ocekuje header pogresne velicine. Problem dodatno opisan u issue  #10 .