### PR TITLE
Prazno polje i generisanje pdf fajla

### DIFF
--- a/document/id.go
+++ b/document/id.go
@@ -155,16 +155,20 @@ func (doc *IdDocument) BuildPdf() (data []byte, fileName string, retErr error) {
 		y1 := pdf.GetY()
 
 		pdf.SetXY(textLeftMargin+128, y)
-		texts, err = pdf.SplitTextWithWordWrap(data, 350)
-		if err != nil {
-			panic(err)
-		}
-
-		for i, text := range texts {
-			cell(text)
-			if i < len(texts)-1 {
-				pdf.SetXY(textLeftMargin+128, pdf.GetY()+12)
+		if data != "" {
+			texts, err = pdf.SplitTextWithWordWrap(data, 350)
+			if err != nil {
+				panic(err)
 			}
+
+			for i, text := range texts {
+				cell(text)
+				if i < len(texts)-1 {
+					pdf.SetXY(textLeftMargin+128, pdf.GetY()+12)
+				}
+			}
+		} else {
+			cell("")
 		}
 
 		y2 := pdf.GetY()


### PR DESCRIPTION
Kod lične karte izdate u 2014. godini je polje za datum promene adrese prazno ukoliko se promena nije dogodila (kod novijih stoji tekst "Nije dostupan") i prilikom poziva `SplitTextWithWordWrap` se javlja greška jer je tekst prazan. Problem je rešen obuhvatanjem okolnog dela koda proverom da li imamo tekst i ako nemamo piše praznu ćeliju u pdf fajl.