### PR TITLE
Check only last two bytes in responseOK

### DIFF
--- a/card/card.go
+++ b/card/card.go
@@ -240,5 +240,10 @@ func buildAPDU(cla, ins, p1, p2 byte, data []byte, ne uint) []byte {
 
 // Checks if the card response indicates no error.
 func responseOK(rsp []byte) bool {
-	return reflect.DeepEqual(rsp, []byte{0x90, 0x00})
+	if len(rsp) < 2 {
+		return false
+	}
+
+	var rspEnd = []byte{rsp[len(rsp)-2], rsp[len(rsp)-1]}
+	return reflect.DeepEqual(rspEnd, []byte{0x90, 0x00})
 }


### PR DESCRIPTION
Testirano sa LK izdatom 19.07.2021 

initCard u mom slucaju vraca response

"\x00\x04\x01\x00\x01\x00\x01\x00\x7f\xff\b\x03\x03\x03\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00?@?\xcf\x0f\x90\x00"

Nisam siguran da je ovo naj idealniji nacin ali ode sam prepravio da se vrsi provera samo na poslednja dva bajta u nizu 

Trebalo bi da resi i ovaj problem

Fix #20 