### PR TITLE
Fix VehicleCard

### DIFF
--- a/card/card.go
+++ b/card/card.go
@@ -46,11 +46,14 @@ func ReadCard(sc Card) (doc.Document, error) {
 			card = VehicleCard{smartCard: sc}
 		}
 	} else if slices.Equal(smartCardStatus.Atr, GEMALTO_ATR_2) {
+		tempIdCard := Gemalto{smartCard: sc}
 		tmpMedCard := MedicalCard{smartCard: sc}
-		if tmpMedCard.testMedicalCard() {
+		if tempIdCard.testGemalto() {
+			card = Gemalto{smartCard: sc}
+		} else if tmpMedCard.testMedicalCard() {
 			card = MedicalCard{smartCard: sc}
 		} else {
-			card = Gemalto{smartCard: sc}
+			card = VehicleCard{smartCard: sc}
 		}
 	} else if slices.Equal(smartCardStatus.Atr, GEMALTO_ATR_3) {
 		card = Gemalto{smartCard: sc}


### PR DESCRIPTION
Fix #22 

- Procerisanje saobracajne sa GEMALTO_ATR_2
- Skitnuta APDU komanda u read metodi jer se u initCard() metodi vec inicializuje katrica. Problem je sto ovde ima 3 nacina inicializacije. U mom slucaju Init prolazi sa drugim setom komandi. U read se poziva komanda iz prvog seta koja deinicializuje karticiu i samim tim dalje ocitavanje nije moguce
- Izmenjeni offseti u readFile metodi kako bi BER-TLV bio kompletan