### PR TITLE
Fix detection of medical docs.

### DIFF
--- a/card/atr.go
+++ b/card/atr.go
@@ -18,10 +18,8 @@ func (atr Atr) Is(otherAtr Atr) bool {
 func DetectCardDocumentByAtr(atr Atr) []CardDocumentType {
 	if atr.Is(GEMALTO_ATR_1) {
 		return []CardDocumentType{GemaltoIdDocumentCardType, VehicleDocumentCardType}
-	} else if atr.Is(GEMALTO_ATR_2) || atr.Is(GEMALTO_ATR_3) {
+	} else if atr.Is(GEMALTO_ATR_2) || atr.Is(GEMALTO_ATR_3) || atr.Is(GEMALTO_ATR_4) {
 		return []CardDocumentType{GemaltoIdDocumentCardType, MedicalDocumentCardType, VehicleDocumentCardType}
-	} else if atr.Is(GEMALTO_ATR_4) {
-		return []CardDocumentType{GemaltoIdDocumentCardType, VehicleDocumentCardType}
 	} else if atr.Is(MEDICAL_ATR_1) || atr.Is(MEDICAL_ATR_2) {
 		return []CardDocumentType{MedicalDocumentCardType}
 	} else if atr.Is(VEHICLE_ATR_0) || atr.Is(VEHICLE_ATR_2) || atr.Is(VEHICLE_ATR_3) || atr.Is(VEHICLE_ATR_4) {


### PR DESCRIPTION
Greetings!

I’ve been using this project to read my family's medical documents. Everything worked well except for one specific card that failed to be detected. While I initially suspected a hardware issue, I was able to read the card successfully using LibreCelik.

After debugging, I discovered that the card returns GEMALTO_ATR_4, which was causing the detection logic to fail. This PR adds support for that ATR, and I can confirm that I am now able to read and print the card data successfully.