### PR TITLE
hotfix: application settings not persisting on restart

### DIFF
--- a/packaging/nfpm/debian.yaml
+++ b/packaging/nfpm/debian.yaml
@@ -18,6 +18,10 @@ contents:
     dst: /usr/bin/bas-celik
     file_info:
       mode: 0755
+  - src: ./FyneApp.toml
+    dst: /usr/bin/FyneApp.toml
+    file_info:
+      mode: 0644
   - src: ./assets/application.desktop
     dst: /usr/share/applications/bas-celik.desktop
     file_info:

--- a/packaging/nfpm/fedora.yaml
+++ b/packaging/nfpm/fedora.yaml
@@ -18,6 +18,10 @@ contents:
     dst: /usr/bin/bas-celik
     file_info:
       mode: 0755
+  - src: ./FyneApp.toml
+    dst: /usr/bin/FyneApp.toml
+    file_info:
+      mode: 0644
   - src: ./assets/application.desktop
     dst: /usr/share/applications/bas-celik.desktop
     file_info:


### PR DESCRIPTION
The GUI used app.New() so Fyne had no stable application ID for storing preferences.
Preferences are scoped by app ID, so without a fixed ID saved settings were not applied after restart.

The fix was tested locally