### PR TITLE
Ispravka latiničnog prezimena nosioca osiguranja u PDF-u zdravstvene knjižice

### DIFF
--- a/document/medical.go
+++ b/document/medical.go
@@ -220,7 +220,7 @@ func (doc *MedicalDocument) BuildPdf() (data []byte, fileName string, retErr err
 
 	putData("Име:", doc.CarrierGivenName+" ("+doc.CarrierGivenNameLatin+")")
 
-	putData("Презиме:", doc.CarrierFamilyName+" ("+doc.CarrierFamilyName+")")
+	putData("Презиме:", doc.CarrierFamilyName+" ("+doc.CarrierFamilyNameLatin+")")
 
 	putData("ЛБО:", doc.CarrierInsurantNumber)
 


### PR DESCRIPTION
## Razlog izmene

U PDF-u zdravstvene knjižice, red sa prezimenom nosioca osiguranja (`document/medical.go`) dva puta ispisuje ćirilično prezime umesto da u zagradi prikaže latiničnu varijantu:

```go
// pre
putData("Презиме:", doc.CarrierFamilyName+" ("+doc.CarrierFamilyName+")")
// posle
putData("Презиме:", doc.CarrierFamilyName+" ("+doc.CarrierFamilyNameLatin+")")
```

Red iznad (ime nosioca, linija 221) ispravno uparuje ćirilično ime sa latiničnom varijantom (`CarrierGivenName` + `CarrierGivenNameLatin`), pa je ovo očigledan copy-paste propust.

## Verifikacija

- `go build ./...` prolazi
- `go test ./document/` prolazi
- `gofmt` čist

Napomena: tekstualni sadržaj generisanog PDF-a se trenutno ne proverava unit testovima, pa nije dodat regresioni test da se ne bi uvodio krhak test koji parsira PDF.