### PR TITLE
Ispravka out-of-bounds panike u parseVehicleCardFileSize

### DIFF
--- a/card/vehicle.go
+++ b/card/vehicle.go
@@ -236,7 +236,7 @@ func (card *VehicleCard) Test() bool {
 }
 
 func parseVehicleCardFileSize(data []byte) (uint, uint, error) {
-	if len(data) < 1 {
+	if len(data) < 2 {
 		return 0, 0, cardErrors.ErrInvalidLength
 	}
 

--- a/card/vehicle_test.go
+++ b/card/vehicle_test.go
@@ -19,6 +19,10 @@ func Test_parseVehicleCardFileSize(t *testing.T) {
 			expectedError: cardErrors.ErrInvalidLength,
 		},
 		{
+			data:          []byte{0x01},
+			expectedError: cardErrors.ErrInvalidLength,
+		},
+		{
 			data:          []byte{0x01, 0x02, 0x03, 0x04},
 			expectedError: cardErrors.ErrInvalidLength,
 		},


### PR DESCRIPTION
## Razlog izmene

Funkcija `parseVehicleCardFileSize` (`card/vehicle.go`) proverava samo da ulaz nije prazan (`len(data) < 1`), ali odmah zatim čita `data[1]`:

```go
if len(data) < 1 {
    return 0, 0, cardErrors.ErrInvalidLength
}
offset := uint(data[1]) + 2
```

Ako čitač vrati zaglavlje od tačno jednog bajta (npr. oštećen ili skraćen odgovor kartice), `data[1]` izaziva `index out of range [1] with length 1` paniku. Granica je promenjena na `len(data) < 2`.

## Verifikacija

Dodat je regresioni test za jednobajtni ulaz. Bez ispravke test panikuje:

```
panic: runtime error: index out of range [1] with length 1
```

Sa ispravkom:

- `go test ./card/` prolazi
- `go build ./...` prolazi
- `gofmt` čist