### PR TITLE
Provera granica nad prosleđenim indeksom pri izboru sertifikata

### DIFF
--- a/internal/gui/crypto.go
+++ b/internal/gui/crypto.go
@@ -171,7 +171,7 @@ func renderCertInformationObjects() ([]fyne.CanvasObject, func(int)) {
 	subjectGroup := widgets.NewGroup(t("crypto.subject"), subjectRow1, subjectRow2, subjectRow3)
 
 	selectCert := func(index int) {
-		if state.selectedCert >= len(state.certs) || state.selectedCert < 0 {
+		if index >= len(state.certs) || index < 0 {
 			return
 		}
 


### PR DESCRIPTION
## Razlog izmene

Funkcija `selectCert(index int)` u `internal/gui/crypto.go` proverava prethodno sačuvanu vrednost `state.selectedCert`, a zatim indeksira `state.certs` **prosleđenim** `index`-om koji nije proveren:

```go
selectCert := func(index int) {
    if state.selectedCert >= len(state.certs) || state.selectedCert < 0 {
        return
    }
    state.selectedCert = index
    cert := state.certs[index] // index nije proveren
```

Ako je `state.selectedCert` validan (npr. ranije postavljen na 0), a `index` van opsega, pristup `state.certs[index]` izaziva paniku. Provera je premeštena na `index` koji se zaista koristi.

## Verifikacija

- `go build ./...` prolazi
- `go test ./internal/gui/` prolazi
- `gofmt` čist