### PR TITLE
Ćirilično „М" za mušku oznaku pola na zdravstvenoj knjižici

### DIFF
--- a/card/medical.go
+++ b/card/medical.go
@@ -271,7 +271,7 @@ func parseMedicalVariableAdminFile(data []byte, doc *document.MedicalDocument) e
 	descramble(fields, 1602)
 	tlv.AssignField(fields, 1602, &doc.ParentNameLatin)
 	if string(fields[1603]) == "01" {
-		doc.Gender = "Mушко"
+		doc.Gender = "Мушко"
 	} else {
 		doc.Gender = "Женско"
 	}


### PR DESCRIPTION
## Razlog izmene

U `parseMedicalVariableAdminFile` (`card/medical.go`) oznaka muškog pola počinje **latiničnim** slovom „M" (U+004D), praćenim ćiriličnim slovima, dok je ženska oznaka „Женско" u potpunosti ćirilična.

Bajtovi pre izmene (prvi bajt `4d` = latinično „M"):
```
22 4d d183 d188 d0ba d0be 22   →  "Mушко"
```

Posle izmene (`d09c` = ćirilično „М"):
```
22 d09c d183 d188 d0ba d0be 22  →  "Мушко"
```

Ovo je verovatno nenamerna greška mešanog pisma; vizuelno su slova gotovo identična, ali se razlikuju u kodiranju.

## Verifikacija

- `go build ./...` prolazi
- `go test ./card/ ./document/` prolazi
- `gofmt` čist