### PR TITLE
Provera indeksa sertifikata pre upotrebe u saveCert

### DIFF
--- a/internal/gui/crypto.go
+++ b/internal/gui/crypto.go
@@ -212,6 +212,10 @@ func renderCertInformationObjects() ([]fyne.CanvasObject, func(int)) {
 }
 
 func saveCert() {
+	if state.selectedCert < 0 || state.selectedCert >= len(state.certs) {
+		return
+	}
+
 	cert := state.certs[state.selectedCert]
 
 	fDialog := dialog.NewFileSave(func(w fyne.URIWriteCloser, err error) {


### PR DESCRIPTION
## Razlog izmene

Funkcija `saveCert` (`internal/gui/crypto.go`) čita `state.certs[state.selectedCert]` i koristi sertifikat (za podrazumevano ime fajla, linija 258) **pre** bilo kakve provere granica. Postojeća provera se nalazi unutar callback-a fajl-dijaloga (linija 227), dakle tek nakon što je vrednost već pristupljena:

```go
func saveCert() {
    cert := state.certs[state.selectedCert] // pristup pre provere
    fDialog := dialog.NewFileSave(func(...) {
        ...
        if state.selectedCert >= len(state.certs) || state.selectedCert < 0 { // prekasno
            return
        }
```

Ako je `state.selectedCert` van opsega (npr. `-1`), `state.certs[...]` izaziva paniku. Dodата je provera na početku funkcije, pre pristupa.

## Verifikacija

- `go build ./...` prolazi
- `go test ./internal/gui/` prolazi
- `gofmt` čist